### PR TITLE
Fix docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     volumes:
       - ./:/workdir
     command: >
-      bash -c "pip uninstall drf-logger &&
+      bash -c "pip uninstall -y drf-logger &&
                python setup.py develop &&
                cd example_project &&
                python manage.py makemigrations &&


### PR DESCRIPTION
- When I run docker-compose, I found this error.
- I fix this problem to add `-y` option.

```shell
django_1  | Found existing installation: drf-logger 0.0.6
django_1  | Uninstalling drf-logger-0.0.6:
django_1  |   Would remove:
django_1  |     /usr/local/lib/python3.7/site-packages/drf-logger.egg-link
django_1  | Proceed (y/n)? ERROR: Exception:
django_1  | Traceback (most recent call last):
django_1  |   File "/usr/local/lib/python3.7/site-packages/pip/_internal/cli/base_command.py", line 186, in _main
django_1  |     status = self.run(options, args)
django_1  |   File "/usr/local/lib/python3.7/site-packages/pip/_internal/commands/uninstall.py", line 79, in run
django_1  |     auto_confirm=options.yes, verbose=self.verbosity > 0,
django_1  |   File "/usr/local/lib/python3.7/site-packages/pip/_internal/req/req_install.py", line 687, in uninstall
django_1  |     uninstalled_pathset.remove(auto_confirm, verbose)
django_1  |   File "/usr/local/lib/python3.7/site-packages/pip/_internal/req/req_uninstall.py", line 388, in remove
django_1  |     if auto_confirm or self._allowed_to_proceed(verbose):
django_1  |   File "/usr/local/lib/python3.7/site-packages/pip/_internal/req/req_uninstall.py", line 431, in _allowed_to_proceed
django_1  |     return ask('Proceed (y/n)? ', ('y', 'n')) == 'y'
django_1  |   File "/usr/local/lib/python3.7/site-packages/pip/_internal/utils/misc.py", line 241, in ask
django_1  |     response = input(message)
django_1  | EOFError: EOF when reading a line
drf-logger_django_1 exited with code 2
```