### PR TITLE
Django json response

### DIFF
--- a/drf_logger/decorators.py
+++ b/drf_logger/decorators.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Callable
 
+from django.http import HttpRequest
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -65,11 +66,9 @@ class APILoggingDecorator(object):
             extra = {}
             extra['function'] = func.__module__ + '.' + func.__qualname__
 
-            # If this decorator used in APIViewSet, request comes as
-            # APIViewSet. And APIViewSet has not attribute user.
             # request.user is django User model or
             # django.contrib.auth.models.AnonymousUser.
-            if isinstance(request, Request):
+            if isinstance(request, (HttpRequest, Request)):
                 extra['user_id'] = request.user.id
 
             response, additionals = func(request, *args, **kwargs)

--- a/drf_logger/decorators.py
+++ b/drf_logger/decorators.py
@@ -3,7 +3,6 @@ from typing import Callable
 
 from django.http import HttpRequest
 from rest_framework.request import Request
-from rest_framework.response import Response
 
 from drf_logger import utils
 
@@ -54,7 +53,7 @@ class APILoggingDecorator(object):
         self.logger = logger
 
     def __call__(self, func: Callable) -> Callable:
-        def wrapper(request, *args, **kwargs) -> Response:
+        def wrapper(request, *args, **kwargs):
 
             # In case decorator used in class based views like
             # rest_framework.viewsets.ModelViewSet, rest_framework.APIView.

--- a/drf_logger/decorators.py
+++ b/drf_logger/decorators.py
@@ -54,11 +54,11 @@ class APILoggingDecorator(object):
         self.logger = logger
 
     def __call__(self, func: Callable) -> Callable:
-        def wrapper(request: Request, *args, **kwargs) -> Response:
+        def wrapper(request, *args, **kwargs) -> Response:
 
             # In case decorator used in class based views like
             # rest_framework.viewsets.ModelViewSet, rest_framework.APIView.
-            if not isinstance(request, Request):
+            if not isinstance(request, (HttpRequest, Request)):
                 if len(args) >= 1:
                     if isinstance(args[0], Request):
                         request = args[0]

--- a/example_project/app/tests.py
+++ b/example_project/app/tests.py
@@ -40,3 +40,12 @@ class PersonAPIViewTests(APITestCase):
         params = {'name': 24, 'age': 'yutayamazaki'}
         r = self.client.post(self.url, params)
         self.assertFalse(status.is_success(r.status_code))
+
+
+class DjangoJsonTests(APITestCase):
+
+    url = '/app/django_json/'
+
+    def test_success(self):
+        r = self.client.get(self.url)
+        self.assertTrue(status.is_success(r.status_code))

--- a/example_project/app/urls.py
+++ b/example_project/app/urls.py
@@ -25,4 +25,5 @@ urlpatterns = [
     path('', include(router.urls)),
     path('hello/', views.hello_api),
     path('person_api/', views.PersonAPIView.as_view()),
+    path('django_json/', views.django_json),
 ]

--- a/example_project/app/views.py
+++ b/example_project/app/views.py
@@ -1,5 +1,6 @@
 from logging import getLogger
 
+from django.http import JsonResponse
 from drf_logger.decorators import APILoggingDecorator
 from rest_framework import status, viewsets
 from rest_framework.views import APIView
@@ -48,3 +49,10 @@ class PersonAPIView(APIView):
         additional = {'message': 'kw', 'level': 'ERROR'}
         res = Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
         return res, additional
+
+
+@api_logger
+def django_json(request):
+    data = {'name': 'django_json'}
+    additional = {'message': 'I am from json response.'}
+    return JsonResponse(data), additional


### PR DESCRIPTION
- Related issue is #11 
- Add an example of `django.http.JsonResponse`
- When we use JsonResponse as a response of django view, `drf_logger.decorators.APILoggingDecorator.__call__` get `django.http.HttpRequest` as request. So I fixed [this line](https://github.com/yutayamazaki/drf-logger/compare/django-json-response?expand=1#diff-d480c39ee8f1c668ad31d2f8464c72a9R71).