### PR TITLE
Run actions when PR created

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,10 @@
 name: Python package
 
-on: [push]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   build:


### PR DESCRIPTION
- #23 

I changed the rules of trigger on GitHub Actions. Actions run their jobs when user create PR for this repository or PR for master branch merged.
